### PR TITLE
Removed unnecessary python package for artful/py3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,6 @@ docker_prerequisite_packages_Ubuntu:
   - {package: "ca-certificates"}
   - {package: "curl"}
   - {package: "software-properties-common"}
-  - {package: "python-docker"}
 
 docker_prerequisite_packages_Ubuntu_1404:
   - {package: "linux-image-extra-{{ ansible_kernel }}"}


### PR DESCRIPTION
The python-docker package is not required as per the docs at https://docs.docker.com/install/linux/docker-ce/ubuntu/#install-using-the-repository .  The package is py2 and should be installed afterwards in a separate task/role if the user wishes.